### PR TITLE
Set System.main to converted name

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -45,7 +45,13 @@ exports.addExtension = function(System){
 				depPkg = utils.pkg.findByName(this, parsedModuleName.packageName);
 			}
 		}
-		
+		// It could be the root main.
+		if(!depPkg && refPkg === this.npmPaths.__default && name === refPkg.main) {
+			parsedModuleName.version = refPkg.version;
+			parsedModuleName.packageName = refPkg.name;
+			parsedModuleName.modulePath = utils.pkg.main(refPkg);
+			return oldNormalize.call(this, utils.moduleName.create(parsedModuleName), parentName, parentAddress);
+		}
 		if( depPkg ) {
 			parsedModuleName.version = depPkg.version;
 			// add the main path

--- a/npm-extension.js
+++ b/npm-extension.js
@@ -46,7 +46,8 @@ exports.addExtension = function(System){
 			}
 		}
 		// It could be the root main.
-		if(!depPkg && refPkg === this.npmPaths.__default && name === refPkg.main) {
+		if(!depPkg && refPkg === this.npmPaths.__default && name === refPkg.main &&
+		  utils.pkg.hasDirectoriesLib(refPkg)) {
 			parsedModuleName.version = refPkg.version;
 			parsedModuleName.packageName = refPkg.name;
 			parsedModuleName.modulePath = utils.pkg.main(refPkg);

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -225,6 +225,10 @@ var utils = {
 			if(loader.npm && !utils.path.startsWithDotSlash(name)) {
 				return loader.npm[name];
 			}
+		},
+		hasDirectoriesLib: function(pkg) {
+			var system = pkg.system;
+			return system && system.directories && !!system.directories.lib;
 		}
 	},
 	path: {

--- a/npm.js
+++ b/npm.js
@@ -61,10 +61,13 @@ exports.translate = function(load){
 			}
 		});
 		var configDependencies = ['@loader','npm-extension'].concat(packageDependencies(pkg));
+		var pkgMain = hasDirectoriesLib(pkg) ?
+			convertName(context, pkg, false, true, pkg.name+"/"+utils.pkg.main(pkg)) :
+			utils.pkg.main(pkg);
 
 		return "define("+JSON.stringify(configDependencies)+", function(loader, npmExtension){\n" +
 			"npmExtension.addExtension(loader);\n"+
-		    (pkg.main ? "if(!System.main){ System.main = "+JSON.stringify(utils.pkg.main(pkg))+"; }\n" : "") + 
+		    (pkg.main ? "if(!loader.main){ loader.main = "+JSON.stringify(pkgMain)+"; }\n" : "") + 
 			"("+translateConfig.toString()+")(loader, "+JSON.stringify(packages, null, " ")+");\n" +
 		"});";
 	});
@@ -95,7 +98,7 @@ function convertPropertyNames (context, pkg, map , root) {
 		return map;
 	}
 	var clone = {};
-	for( property in map ) {
+	for(var property in map ) {
 		clone[convertName(context, pkg, map, root, property)] = map[property];
 		// do root paths b/c we don't know if they are going to be included with the package name or not.
 		if(root) {
@@ -111,7 +114,7 @@ function convertPropertyNamesAndValues (context, pkg, map , root) {
 		return map;
 	}
 	var clone = {};
-	for( property in map ) {
+	for(var property in map ) {
 		clone[convertName(context, pkg, map, root, property)] = convertName(context, pkg, map, root, map[property]);
 	}
 	return clone;
@@ -132,12 +135,11 @@ function convertName (context, pkg, map, root, name) {
 		return utils.moduleName.create(parsed);
 		
 	} else {
-		
-		if(root && property.substr(0,2) === "./" ) {
-			return property.substr(2);
+		if(root && name.substr(0,2) === "./" ) {
+			return name.substr(2);
 		} else {
 			// this is for a module within the package
-			if (property.substr(0,2) === "./" ) {
+			if (name.substr(0,2) === "./" ) {
 				return utils.moduleName.create({
 					packageName: pkg.name,
 					modulePath: name,
@@ -295,4 +297,7 @@ var translateConfig = function(loader, packages){
 	});
 };
 
-
+function hasDirectoriesLib(pkg) {
+	var system = pkg.system;
+	return system && system.directories && !!system.directories.lib;
+}

--- a/npm.js
+++ b/npm.js
@@ -61,7 +61,7 @@ exports.translate = function(load){
 			}
 		});
 		var configDependencies = ['@loader','npm-extension'].concat(packageDependencies(pkg));
-		var pkgMain = hasDirectoriesLib(pkg) ?
+		var pkgMain = utils.pkg.hasDirectoriesLib(pkg) ?
 			convertName(context, pkg, false, true, pkg.name+"/"+utils.pkg.main(pkg)) :
 			utils.pkg.main(pkg);
 
@@ -296,8 +296,3 @@ var translateConfig = function(loader, packages){
 		loader.npmPaths[pkgAddress] = pkg;
 	});
 };
-
-function hasDirectoriesLib(pkg) {
-	var system = pkg.system;
-	return system && system.directories && !!system.directories.lib;
-}

--- a/package.json
+++ b/package.json
@@ -21,23 +21,34 @@
   "homepage": "https://github.com/bitovi/npm-bower",
   "devDependencies": {
     "bower": "^1.3.12",
-    "grunt": "^0.4.5",
-    "testee": "^0.1.7",
-    "qunit": "~0.7.5",
-    "lodash": "~2.4.1",
-    "jquery-ui": "^1.10.5",
-    "can": "bitovi/canjs#minor",
-    "steal": "bitovi/steal#npm",
-    "systemjs": "bitovi/systemjs#b664e4cd359c013acb3445627d1e1e1799424542",
-    "transpile": "bitovi/transpile#browser",
     "browser-builtins": "bitovi/node-browser-builtins#master",
+    "can": "bitovi/canjs#minor",
+    "grunt": "^0.4.5",
+    "jquery": "^2.1.3",
+    "jquery-ui": "^1.10.5",
+    "lodash": "~2.4.1",
+    "qunit": "~0.7.5",
+    "steal": "bitovi/steal#npm",
+    "steal-qunit": "bitovi/steal-qunit#master",
     "system-json": "bitovi/system-json#master",
-    "steal-qunit": "bitovi/steal-qunit#master"
+    "systemjs": "bitovi/systemjs#b664e4cd359c013acb3445627d1e1e1799424542",
+    "testee": "^0.1.7",
+    "transpile": "bitovi/transpile#browser"
   },
   "system": {
-  	"npmIgnore": ["bower","grunt","testee","systemjs","steal","qunit"],
-  	"meta": {
-  		"./test/meta": {"format": "global", "exports": "foo"}
-  	}
+    "npmIgnore": [
+      "bower",
+      "grunt",
+      "testee",
+      "systemjs",
+      "steal",
+      "qunit"
+    ],
+    "meta": {
+      "./test/meta": {
+        "format": "global",
+        "exports": "foo"
+      }
+    }
   }
 }

--- a/test/directories_lib/dev.html
+++ b/test/directories_lib/dev.html
@@ -51,7 +51,7 @@
 				}
 			});
 			
-			Promise.all([packageName,packageUtil,test]).then(function(){
+			Promise.all([packageName,packageUtil,test,main]).then(function(){
 				removeMyself && removeMyself();
 			}, function(e){
 				if(window.QUnit) {

--- a/test/directories_lib/dev.html
+++ b/test/directories_lib/dev.html
@@ -42,6 +42,14 @@
 					QUnit.equal(test.directories_lib.util.name, "util");
 				}
 			});
+
+			var main = System.import(System.main).then(function(main){
+				if(window.QUnit) {
+					QUnit.equal(main.default.util.name, "util");
+				} else {
+					console.log(main);
+				}
+			});
 			
 			Promise.all([packageName,packageUtil,test]).then(function(){
 				removeMyself && removeMyself();

--- a/test/directories_lib/package.json
+++ b/test/directories_lib/package.json
@@ -1,5 +1,6 @@
 {
   "name": "directories_lib",
+  "main": "main.js",
   "version": "0.0.0",
   "dependencies": {
     "dep": "1.2.2"

--- a/test/test.js
+++ b/test/test.js
@@ -73,12 +73,12 @@ asyncTest("transpile works", function(){
 	}).then(start);
 });
 
-
 asyncTest("Loads globals", function(){
 	GlobalSystem.import("jquery").then(function($){
 		ok($.fn.jquery, "jQuery loaded");
-	}).then(start);
+	}).then(start, start);
 });
+
 
 asyncTest("meta", function(){
 
@@ -102,7 +102,7 @@ asyncTest("jquery-ui", function(){
 	]).then(function(mods){
 		var $ = mods[0];
 		ok($.fn.draggable);
-	}).then(start);
+	}).then(start, start);
 
 });
 


### PR DESCRIPTION
This makes System.main that is set in the extension to be converted first. This is necessary so that steal.startup will be able to startup an application that defines its main in the package.json. Fixes #10

Depends on #11