### PR TITLE
Relative paths outside directories.lib should be normalized the normal way

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -18,6 +18,13 @@ exports.addExtension = function(System){
 	 */
 	var oldNormalize = System.normalize;
 	System.normalize = function(name, parentName, parentAddress){
+		// If this is a relative module name and the parent is not an npm module
+		// we can skip all of this logic.
+		if(parentName && utils.path.isRelative(name) && 
+		  !utils.moduleName.isNpm(parentName)) {
+			return oldNormalize.call(this, name, parentName, parentAddress);
+		}
+
 		// Get the current package
 		var refPkg = utils.pkg.findByModuleNameOrAddress(this, parentName, parentAddress);
 		

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -6,6 +6,9 @@
  * However, it can have all npm-extension helpers.
  */
 
+// A regex to test if a moduleName is npm-like.
+var npmModuleRegEx = /.+@.+\..+\..+#.+/;
+
 var utils = {
 	extend: function(d, s){
 		for(var prop in s) {
@@ -63,7 +66,7 @@ var utils = {
 		 * @return {Boolean}
 		 */
 		isNpm: function(moduleName){
-			return /.+@.+\..+\..+#.+/.test(moduleName);
+			return npmModuleRegEx.test(moduleName);
 		},
 		/**
 		 * @function moduleName.parse

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -33,7 +33,7 @@ var utils = {
 	forEach: function(arr, fn) {
 		var i = 0, len = arr.length;
 		for(; i < len; i++) {
-			fn.call(arr, arr[i]);
+			fn.call(arr, arr[i], i);
 		}
 	},
 	moduleName: {
@@ -63,7 +63,7 @@ var utils = {
 		 * @return {Boolean}
 		 */
 		isNpm: function(moduleName){
-			return /.+@\d+\.\d+\.\d+#.+/.test(moduleName);
+			return /.+@.+\..+\..+#.+/.test(moduleName);
 		},
 		/**
 		 * @function moduleName.parse

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -58,6 +58,14 @@ var utils = {
 			}
 		},
 		/**
+		 * @function moduleName.isNpm
+		 * Determines whether a moduleName is npm-like.
+		 * @return {Boolean}
+		 */
+		isNpm: function(moduleName){
+			return /.+@\d+\.\d+\.\d+#.+/.test(moduleName);
+		},
+		/**
 		 * @function moduleName.parse
 		 * Breaks a string moduleName into parts.
 		 * packageName@version!plugin#modulePath

--- a/test/directories_lib/dev.html
+++ b/test/directories_lib/dev.html
@@ -40,6 +40,7 @@
 					QUnit.equal(test.name, "test/test","got name");
 					QUnit.equal(test.foo.name, "foo");
 					QUnit.equal(test.directories_lib.util.name, "util");
+					QUnit.equal(test.other.foo, "bar");
 				}
 			});
 

--- a/test/directories_lib/dev.html
+++ b/test/directories_lib/dev.html
@@ -40,7 +40,7 @@
 					QUnit.equal(test.name, "test/test","got name");
 					QUnit.equal(test.foo.name, "foo");
 					QUnit.equal(test.directories_lib.util.name, "util");
-					QUnit.equal(test.other.foo, "bar");
+					QUnit.equal(test.other, "bar");
 				}
 			});
 

--- a/test/directories_lib/test/another.js
+++ b/test/directories_lib/test/another.js
@@ -1,0 +1,1 @@
+export var foo = "bar";

--- a/test/directories_lib/test/test.js
+++ b/test/directories_lib/test/test.js
@@ -1,7 +1,6 @@
 import foo from "directories_lib/foo";
 import directories_lib from "directories_lib";
-import other from "./another";
-
+import { foo as other } from "./another";
 
 export default {
 	name: "test/test",

--- a/test/directories_lib/test/test.js
+++ b/test/directories_lib/test/test.js
@@ -1,5 +1,11 @@
 import foo from "directories_lib/foo";
 import directories_lib from "directories_lib";
+import other from "./another";
 
 
-export default {name: "test/test", foo: foo, directories_lib: directories_lib};
+export default {
+	name: "test/test",
+	foo: foo,
+	directories_lib: directories_lib,
+	other: other
+};

--- a/test/steal.html
+++ b/test/steal.html
@@ -5,7 +5,7 @@
 	<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
 </head>
 <body>
-	<h1 id="qunit-header">system-bower Steal Test Suite</h1>
+	<h1 id="qunit-header">system-npm Steal Test Suite</h1>
 		
 	<h2 id="qunit-banner"></h2>
 	<div id="qunit-testrunner-toolbar"></div>

--- a/test/systemjs.html
+++ b/test/systemjs.html
@@ -5,7 +5,7 @@
 	<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
 </head>
 <body>
-	<h1 id="qunit-header">system-bower SystemJS Test Suite</h1>
+	<h1 id="qunit-header">system-npm SystemJS Test Suite</h1>
 		
 	<h2 id="qunit-banner"></h2>
 	<div id="qunit-testrunner-toolbar"></div>


### PR DESCRIPTION
Fixes #15.  We know that if a module identifier is relative that we should only do npm normalization on it if we are currently inside an npm package (which we can tell by the module name).