### PR TITLE
Override incoming map and paths

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -87,7 +87,7 @@ exports.addExtension = function(System){
 		var parsedModuleName = utils.moduleName.parse(load.name),
 			loader = this;
 		// @ is not the first character
-		if(parsedModuleName.version && this.npm) {
+		if(parsedModuleName.version && this.npm && !loader.paths[load.name]) {
 			var pkg = this.npm[parsedModuleName.packageName];
 			if(pkg) {
 				return oldLocate.call(this, load).then(function(address){

--- a/npm.js
+++ b/npm.js
@@ -23,6 +23,8 @@ if(!System.has("@loader")) {
  * @return {Promise} a promise to resolve with the load's new source.
  */
 exports.translate = function(load){
+	var loader = this;
+
 	// This could be an empty string if the fetch failed.
 	if(load.source == "") {
 		return "define([]);";

--- a/test/map_paths/dev.html
+++ b/test/map_paths/dev.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+		function hasQUnit() {
+			return typeof QUnit !== "undefined";
+		}
+
+		System.import("package.json!npm").then(function(){
+			System.config({
+				map: {
+					"dep/dep": "dep"
+				},
+				paths: {
+					"dep": "util.js"
+				}
+			});
+
+			if(hasQUnit()) {
+				QUnit.equal(System.map["dep@1.2.2#dep"], "dep@1.2.2#main");
+				QUnit.equal(System.paths["dep@1.2.2#main"], "util.js");
+			
+				removeMyself();
+			}
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		});
+	</script>
+</body>
+</html>

--- a/test/map_paths/node_modules/dep/library.js
+++ b/test/map_paths/node_modules/dep/library.js
@@ -1,0 +1,3 @@
+module.exports = function(){
+	return "library";
+};

--- a/test/map_paths/node_modules/dep/main.js
+++ b/test/map_paths/node_modules/dep/main.js
@@ -1,0 +1,1 @@
+var util = require("./util");

--- a/test/map_paths/node_modules/dep/package.json
+++ b/test/map_paths/node_modules/dep/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dep",
+  "version": "1.2.2",
+  "main": "main.js",
+  "system": {
+  }
+}

--- a/test/map_paths/node_modules/dep/util.js
+++ b/test/map_paths/node_modules/dep/util.js
@@ -1,0 +1,3 @@
+module.exports = function(){
+	return "util";
+};

--- a/test/map_paths/package.json
+++ b/test/map_paths/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "map_paths",
+  "version": "0.0.0",
+  "dependencies": {
+    "dep": "1.2.2"
+  },
+  "system": {
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -144,6 +144,10 @@ asyncTest("works with packages that have multiple versions of the same dependenc
 	makeIframe("mult_dep/dev.html");
 });
 
+asyncTest("works when System.map and System.paths are provided", function(){
+	makeIframe("map_paths/dev.html");
+});
+
 // Only run these tests for StealJS (because it requires steal syntax)
 if(window.steal) {
 	asyncTest("canjs", function(){


### PR DESCRIPTION
This adds some functionality to npm-extension so that when System.config
is called it will convert the names of map and paths and the values of
map for names that are part of an npm package. Fixes #23 

Testing this out in Steal and Steal-Tools first.